### PR TITLE
docs(resources): add color website to the project resources section

### DIFF
--- a/source-web/src/assets/db/colors.json
+++ b/source-web/src/assets/db/colors.json
@@ -303,5 +303,14 @@
 		"tags": ["Generator", "Preview"],
 		"license": "Apache V2.0",
 		"licenseLink": "https://github.com/material-foundation/material-theme-builder/blob/main/LICENSE"
+	},
+	{
+  "id": 41,
+  "order": 77,
+  "name": "GradientsCSS",
+  "img": "https://res.cloudinary.com/cosmocloudinary/image/upload/freesets/design/gradientscss",
+  "link": "https://gradientscss.vercel.app/",
+  "tags": ["Gradients"]
 	}
+
 ]


### PR DESCRIPTION
# Add GradientsCSS Resource

This pull request adds the **GradientsCSS** resource to the Freesets database.

## Checklist

- [ ] My changes were made in the `source-web/src/assets/db` folder.
- [ ] The resource is completely or partially free.
- [ ] The resource is not already in the database.
- [ ] All resource fields include `id`, `order`, `name`, `link`, and `img`.
- [ ] Both the `id` and the image URL are unique and not duplicated elsewhere.

**Description:**  
GradientsCSS offers curated gradients for use in design projects.
