### PR TITLE
add tldraw in tools

### DIFF
--- a/source-web/src/assets/db/tools.json
+++ b/source-web/src/assets/db/tools.json
@@ -262,5 +262,14 @@
 		"link": "https://www.gradii.fun/",
 		"img": "https://res.cloudinary.com/cosmocloudinary/image/upload/freesets/backgrounds/gradii",
 		"tags": ["Open Graph"]
+	},
+	{
+		"id": 33,
+		"order": 38,
+		"name": "tldraw",
+		"link": "https://www.tldraw.com/",
+		"img": "https://res.cloudinary.com/cosmocloudinary/image/upload/freesets/tools/tldraw",
+		"tags": ["Whiteboard"],
+		"licenseLink":"https://github.com/tldraw/tldraw?tab=License-1-ov-file"
 	}
 ]


### PR DESCRIPTION
# Add tldraw resources

You can check this by visiting:
🌐 [https://tldraw.dev/](https://tldraw.dev) or [https://github.com/tldraw/tldraw](https://github.com/tldraw/tldraw)

* [x] My changes were made in the `source-web/src/assets/db` folder.
* [x] The resource(s) is completely or partially free.
* [x] The resource(s) is not already in the database.
* [x] All resources have an id, order, name, link and img.
* [x] The ids and urls of the images are not repeated.
